### PR TITLE
Disable text boxes when disabling check boxes

### DIFF
--- a/src/wxCheckRadioBox.cpp
+++ b/src/wxCheckRadioBox.cpp
@@ -175,6 +175,13 @@ void wxCheckRadioBox::SetAllUncheckedEnabled(bool nstate)
             rbCheckboxes[i]->Enable(nstate);
         }
     }
+    size_t norm_num = rbCheckboxes.size() - rbTextCtrls.size();
+    for (i=0; i < rbTextCtrls.size(); i++)
+    {
+        if (!rbCheckboxes[i+norm_num]->GetValue()) {
+            rbTextCtrls[i]->Enable(nstate);
+        }
+    }
 }
 
 void wxCheckRadioBox::SetSelected(size_t max_selected, const wxString *sel_options, size_t sel_options_num)


### PR DESCRIPTION
The UI only allows you to select 4 in-game resolutions for KeeperFX, this enhances that.

Disables/Enables text boxes which are not associated with a selected resolution. This mirrors the behaviour of the checkboxes (and now means the custom resolutions behave the same as the selectable ones).

The Settings Editor with this patch:
![image](https://user-images.githubusercontent.com/1984342/88965849-46f22d00-d2a3-11ea-8472-a28f83032f0b.png)


Any values in these unselected boxes are not saved anyway, so you only need to edit them if you have/are going to select them. This also makes it clearer to the user that the limit has been reached.