### PR TITLE
Checkboxes no longer become unclickable

### DIFF
--- a/src/wxCheckRadioBox.cpp
+++ b/src/wxCheckRadioBox.cpp
@@ -79,6 +79,7 @@ void wxCheckRadioBox::ClearOptionCheckboxes(void)
         delete *iter;
     }
     rbTextCtrls.clear();
+    rbPanel->GetSizer()->Clear(true);
     rbPanel->SetSizer(NULL);
 }
 


### PR DESCRIPTION
Whenever the checkboxes were cleared and recreated, some of them were not clickable.

The issue was a child sizer (rbCustPanelSizer) was not being removed with:
rbPanel->SetSizer(NULL);

This left some empty panels that conflicted with the new ones.

Adding the line:
rbPanel->GetSizer()->Clear(true);
clears the child elements of the sizer (rbPanelSizer) first. This fixes both issues in dkfans/keeperfx-launcherwx#4