### PR TITLE
Resize window on creation for High DPI

### DIFF
--- a/src/CommandOptions.cpp
+++ b/src/CommandOptions.cpp
@@ -283,6 +283,7 @@ CommandOptions::CommandOptions(wxFrame *parent)
     topsizer->Add(dlgBottomPanel, 0, wxEXPAND);
 
     SetSizer(topsizer);
+	Fit();
     Centre(wxBOTH);
 }
 

--- a/src/CommandOptions.cpp
+++ b/src/CommandOptions.cpp
@@ -133,6 +133,7 @@ CommandOptions::CommandOptions(wxFrame *parent)
     cmdFlagsBox->SetToolTip(options_tooltips_eng[3],options_tooltips_eng[3]);
     wxStaticBoxSizer* cmdFlagsBoxSizer = new wxStaticBoxSizer( cmdFlagsBox, wxHORIZONTAL );
     cmdFlagsBoxSizer->Add(cmdFlagsBox->rbPanel, 1, wxEXPAND); // for wxStaticBox, we're adding sizer instead of the actual wxStaticBox instance
+    cmdFlagsBoxSizer->SetMinSize(480, 189);
     topsizer->Add(cmdFlagsBoxSizer, 1, wxEXPAND);
 
     wxPanel *cmdOtherPanel = new wxPanel(this, wxID_ANY);
@@ -283,7 +284,7 @@ CommandOptions::CommandOptions(wxFrame *parent)
     topsizer->Add(dlgBottomPanel, 0, wxEXPAND);
 
     SetSizer(topsizer);
-	Fit();
+    Fit();
     Centre(wxBOTH);
 }
 

--- a/src/GameSettings.cpp
+++ b/src/GameSettings.cpp
@@ -30,6 +30,7 @@
 #include <wx/fileconf.h>
 #include <wx/tokenzr.h>
 #include <wx/valnum.h>
+#include <wx/display.h>
 #include "wxCheckRadioBox.hpp"
 
 wxString supported_boolean_code[] = {
@@ -332,6 +333,9 @@ GameSettings::GameSettings(wxFrame *parent)
     topsizer->Add(dlgBottomPanel, 0, wxEXPAND);
 
     SetSizer(topsizer);
+	if (wxDisplay().GetGeometry().GetHeight() > 600) { // Defined pixels size are for 800x600, so don't adjust them with Fit(), use exactly what is defined above
+		Fit(); // Make sure, on Higher DPI settings, that the window is big enough for its contents
+	}
     Centre(wxBOTH);
 
 }


### PR DESCRIPTION
Another quick fix to help higher DPI users.

Running Fit(); will resize the window to fit all of the contents. This is needed for users with a DPI set above "100%", otherwise the window is too small to see all of the options.

There is a check for 600p, that is mainly for forward compatability with the unofficial branch. Running Fit() may adjust the dimensions of the window slightly from what is configured above, in the case of the unofficial branch, this would make the window too tall at 600p. Hence the if statement. For any higher resolution, this growth is irrelevant, and the benefit of the wxWidget calculation, is more evenly spaced checkboxes etc.

There is some additional work for higher DPI settings, but this would require a resonable amount of work. Changing values from pixels to points, and (potentially from what I read) not relying on static boxes etc: https://forums.wxwidgets.org/viewtopic.php?f=1&t=46418
wxWindow::GetDPIScaleFactor :-https://docs.wxwidgets.org/trunk/classwx_window.html#a22e9ffc6ad8aba15eecf5537f3b7791f

![image](https://user-images.githubusercontent.com/1984342/89127030-54492a80-d4e2-11ea-9fa8-bf3457d72315.png)

Look at the above image of the new results, you can see that some of the elements (text boxes and radiobutton labels) are not ideal, the textboxes can be improved by expanding the window's width, the labels cannot be improved by resizing the window. The Launcher window needs a bit of work, but is functional at 200% (the picture is 150%).